### PR TITLE
Add slide transcription package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-# slides-transcription
+# Slides Transcription
+
+A simple tool that extracts audio from Microsoft PowerPoint presentations and transcribes each slide using [OpenAI Whisper](https://github.com/openai/whisper). A minimal GUI can be launched via [Gooey](https://github.com/chriskiehl/Gooey).
+
+## Installation
+
+Install the package using `pip` (preferably in a virtual environment):
+
+```bash
+pip install -e .
+```
+
+The command will install the required dependencies such as `python-pptx`, `openai-whisper` and `gooey`.
+
+## Usage
+
+Run the command line interface:
+
+```bash
+transcribe-slides path/to/presentation.pptx output_dir --model base
+```
+
+Add `--gui` to launch a GUI instead of the CLI.
+
+The tool extracts audio from each slide and writes a text file per slide inside the `output_dir` folder (`slide1.txt`, `slide2.txt`, ...).
+
+## License
+
+This project is released under the MIT License.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["setuptools>=42"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "slides-transcriber"
+version = "0.1.0"
+description = "Transcribe audio from PowerPoint slides using Whisper"
+authors = [{name="Jash Vira"}]
+requires-python = ">=3.8"
+dependencies = [
+    "python-pptx",
+    "openai-whisper",
+    "gooey>=1.0",
+]
+
+[project.scripts]
+transcribe-slides = "transcriber.transcribe_slides:main"

--- a/transcriber/__init__.py
+++ b/transcriber/__init__.py
@@ -1,0 +1,2 @@
+__all__ = ["cli", "transcribe_slides"]
+__version__ = "0.1.0"

--- a/transcriber/cli.py
+++ b/transcriber/cli.py
@@ -1,0 +1,24 @@
+import argparse
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Transcribe slide audio using Whisper")
+    parser.add_argument("pptx", help="Path to PPTX file")
+    parser.add_argument("output", help="Output directory for transcripts")
+    parser.add_argument(
+        "--model",
+        default="base",
+        help="Whisper model name or path (default: base)",
+    )
+    parser.add_argument(
+        "--gui",
+        action="store_true",
+        help="Launch a GUI instead of the CLI",
+    )
+    return parser
+
+
+def parse_args(argv=None):
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args

--- a/transcriber/transcribe_slides.py
+++ b/transcriber/transcribe_slides.py
@@ -1,0 +1,65 @@
+import os
+import tempfile
+import zipfile
+from argparse import Namespace
+
+from gooey import Gooey
+from pptx import Presentation
+import whisper
+
+from .cli import build_parser
+
+
+def extract_slide_audio(pptx_path: str, temp_dir: str):
+    """Extract audio files from a PPTX and yield (index, path) tuples."""
+    prs = Presentation(pptx_path)
+    z = zipfile.ZipFile(pptx_path)
+    for idx, slide in enumerate(prs.slides, start=1):
+        rels_name = f"ppt/slides/_rels/slide{idx}.xml.rels"
+        if rels_name not in z.namelist():
+            continue
+        with z.open(rels_name) as rels_file:
+            content = rels_file.read().decode("utf-8")
+        # Very naive search for media targets
+        for line in content.splitlines():
+            if "media" in line and "Target" in line:
+                target = line.split("Target=")[-1].split('"')[1]
+                if not target.startswith(".."):
+                    media_path = f"ppt/slides/{target}"
+                else:
+                    media_path = target.replace("../", "ppt/")
+                if media_path not in z.namelist():
+                    continue
+                ext = os.path.splitext(media_path)[1]
+                out_path = os.path.join(temp_dir, f"slide{idx}{ext}")
+                with z.open(media_path) as media_file, open(out_path, "wb") as out:
+                    out.write(media_file.read())
+                yield idx, out_path
+
+
+def run(args: Namespace):
+    os.makedirs(args.output, exist_ok=True)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        audio_files = list(extract_slide_audio(args.pptx, tmpdir))
+        if not audio_files:
+            print("No audio found in PPTX")
+            return
+        model = whisper.load_model(args.model)
+        for idx, audio_path in audio_files:
+            result = model.transcribe(audio_path)
+            text = result.get("text", "").strip()
+            out_file = os.path.join(args.output, f"slide{idx}.txt")
+            with open(out_file, "w", encoding="utf-8") as f:
+                f.write(text)
+            print(f"Transcribed slide {idx} -> {out_file}")
+
+
+@Gooey(program_name="Slides Transcriber")
+def main():
+    parser = build_parser()
+    args = parser.parse_args()
+    run(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add pyproject with dependencies and CLI entry point
- implement `transcriber` package with CLI argument parsing
- support a Gooey-based GUI in `transcribe_slides.py`
- document install and usage in README

## Testing
- `python -m py_compile transcriber/*.py`
- `pip install -e . --no-deps`

------
https://chatgpt.com/codex/tasks/task_b_684784afbdac83318ade9a610f0cf53d