### PR TITLE
Add build scripts and enhanced CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@ __pycache__/
 # Distribution / packaging
 .Python
 build/
+!build/
+!build/build.sh
+!build/installer.nsi
+!build/transcribe_slides.spec
 develop-eggs/
 dist/
 downloads/
@@ -31,6 +35,7 @@ MANIFEST
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec
+!build/transcribe_slides.spec
 
 # Installer logs
 pip-log.txt

--- a/README.md
+++ b/README.md
@@ -17,12 +17,32 @@ The command will install the required dependencies such as `python-pptx`, `opena
 Run the command line interface:
 
 ```bash
-transcribe-slides path/to/presentation.pptx output_dir --model base
+transcribe-slides path/to/presentation.pptx output_dir \
+    --model base --language en --task transcribe --prefix slide
 ```
 
 Add `--gui` to launch a GUI instead of the CLI.
 
+The available options are:
+
+* `--model` – Whisper model name or path.
+* `--language` – language spoken in the audio.
+* `--task` – Whisper task (`transcribe` or `translate`).
+* `--prefix` – prefix used when naming transcript files.
+
 The tool extracts audio from each slide and writes a text file per slide inside the `output_dir` folder (`slide1.txt`, `slide2.txt`, ...).
+
+### Building the Windows installer
+
+The repository contains basic scripts to build a standalone executable and NSIS installer. You need [PyInstaller](https://pyinstaller.org/) and [NSIS](https://nsis.sourceforge.io/) available on your system.
+
+Run the build script from the project root:
+
+```bash
+bash build/build.sh
+```
+
+This produces `dist/transcribe-slides.exe` and `dist/SlidesTranscriberSetup.exe`.
 
 ## License
 

--- a/build/build.sh
+++ b/build/build.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build executable with PyInstaller
+pyinstaller build/transcribe_slides.spec --distpath dist --workpath build/tmp
+
+# Build NSIS installer
+if command -v makensis >/dev/null 2>&1; then
+    makensis build/installer.nsi
+else
+    echo "makensis not found. Skipping NSIS installer." >&2
+fi

--- a/build/installer.nsi
+++ b/build/installer.nsi
@@ -1,0 +1,30 @@
+!define APPNAME "SlidesTranscriber"
+!define EXE_NAME "transcribe-slides.exe"
+!define OUTFILE "SlidesTranscriberSetup.exe"
+
+OutFile "dist\${OUTFILE}"
+InstallDir "$PROGRAMFILES\${APPNAME}"
+RequestExecutionLevel user
+
+Page directory
+Page instfiles
+Page uninstConfirm
+Page uninstInstfiles
+
+Section "Install"
+  SetOutPath "$INSTDIR"
+  File "dist\${EXE_NAME}"
+  CreateShortcut "$DESKTOP\${APPNAME}.lnk" "$INSTDIR\${EXE_NAME}"
+  CreateDirectory "$SMPROGRAMS\${APPNAME}"
+  CreateShortcut "$SMPROGRAMS\${APPNAME}\${APPNAME}.lnk" "$INSTDIR\${EXE_NAME}"
+  WriteUninstaller "$INSTDIR\uninstall.exe"
+SectionEnd
+
+Section "Uninstall"
+  Delete "$DESKTOP\${APPNAME}.lnk"
+  Delete "$SMPROGRAMS\${APPNAME}\${APPNAME}.lnk"
+  RMDir "$SMPROGRAMS\${APPNAME}"
+  Delete "$INSTDIR\${EXE_NAME}"
+  Delete "$INSTDIR\uninstall.exe"
+  RMDir "$INSTDIR"
+SectionEnd

--- a/build/transcribe_slides.spec
+++ b/build/transcribe_slides.spec
@@ -1,0 +1,39 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+block_cipher = None
+
+a = Analysis(
+    ['transcriber/transcribe_slides.py'],
+    pathex=[],
+    binaries=[],
+    datas=[],
+    hiddenimports=['pptx', 'gooey', 'whisper'],
+    hookspath=[],
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+)
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+exe = EXE(
+    pyz,
+    a.scripts,
+    exclude_binaries=True,
+    name='transcribe-slides',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=True,
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name='transcribe-slides',
+)

--- a/transcriber/cli.py
+++ b/transcriber/cli.py
@@ -11,6 +11,22 @@ def build_parser() -> argparse.ArgumentParser:
         help="Whisper model name or path (default: base)",
     )
     parser.add_argument(
+        "--language",
+        default="en",
+        help="Language spoken in the audio (default: en)",
+    )
+    parser.add_argument(
+        "--task",
+        default="transcribe",
+        choices=["transcribe", "translate"],
+        help="Whisper task to perform (default: transcribe)",
+    )
+    parser.add_argument(
+        "--prefix",
+        default="slide",
+        help="Filename prefix for transcripts (default: slide)",
+    )
+    parser.add_argument(
         "--gui",
         action="store_true",
         help="Launch a GUI instead of the CLI",

--- a/transcriber/transcribe_slides.py
+++ b/transcriber/transcribe_slides.py
@@ -48,27 +48,35 @@ def run(args: Namespace):
             return
         model = whisper.load_model(args.model)
         for idx, track_idx, audio_path in audio_files:
-            result = model.transcribe(audio_path)
+            result = model.transcribe(
+                audio_path,
+                language=args.language,
+                task=args.task,
+            )
             text = result.get("text", "").strip()
-            out_name = f"slide{idx}_{track_idx}.txt"
+            out_name = f"{args.prefix}{idx}_{track_idx}.txt"
             out_file = os.path.join(args.output, out_name)
             with open(out_file, "w", encoding="utf-8") as f:
                 f.write(text)
             print(f"Transcribed slide {idx} track {track_idx} -> {out_file}")
 
 
-def main():
-    if "--gui" in os.sys.argv:
+def main(argv=None):
+    parser = build_parser()
+    if argv is None:
+        argv = os.sys.argv[1:]
+
+    if "--gui" in argv:
+        argv.remove("--gui")
+
         @Gooey(program_name="Slides Transcriber")
         def _gui_main():
-            parser = build_parser()
-            args = parser.parse_args()
+            args = parser.parse_args(argv)
             run(args)
 
         _gui_main()
     else:
-        parser = build_parser()
-        args = parser.parse_args()
+        args = parser.parse_args(argv)
         run(args)
 
 


### PR DESCRIPTION
## Summary
- extend command line options for language, task, and filename prefix
- update transcriber to pass new options and improve GUI handling
- document usage and installer creation steps
- provide PyInstaller spec and NSIS installer script
- add build helper script

## Testing
- `pytest -q`
- `bash build/build.sh` *(fails: pyinstaller not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6847844bf9dc83318ada978781952476