### PR TITLE
Add documentation and tidy imports

### DIFF
--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,7 +1,6 @@
 import os
 import sys
 from argparse import Namespace
-from io import StringIO
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from transcriber.transcribe_slides import run

--- a/transcriber/__init__.py
+++ b/transcriber/__init__.py
@@ -1,2 +1,4 @@
+"""Slides transcription package."""
+
 __all__ = ["cli", "transcribe_slides"]
 __version__ = "0.1.0"

--- a/transcriber/cli.py
+++ b/transcriber/cli.py
@@ -1,3 +1,5 @@
+"""Command line interface for transcribing slide audio."""
+
 import argparse
 import os
 from gooey import Gooey, GooeyParser
@@ -5,6 +7,8 @@ from transcriber.transcribe_slides import transcribe_slides
 
 
 def build_parser():
+    """Return an argument parser for the CLI."""
+
     parser = argparse.ArgumentParser(
         description="Transcribe slide audio using the OpenAI Speech to Text API"
     )
@@ -52,6 +56,8 @@ def build_parser():
     navigation='TABBED'
 )
 def main():
+    """Entry point for the GUI/CLI application."""
+
     parser = GooeyParser(description="Transcribe audio from PowerPoint slides")
 
     # Input/Output group

--- a/transcriber/transcribe_slides.py
+++ b/transcriber/transcribe_slides.py
@@ -1,7 +1,8 @@
+"""Utilities for extracting and transcribing slide audio."""
+
 import os
 import tempfile
 import zipfile
-from argparse import Namespace
 from xml.etree import ElementTree as ET
 from collections import defaultdict
 
@@ -101,6 +102,8 @@ def transcribe_slides(pptx_path: str, output_dir: str, model: str = "whisper-1",
 
 
 def main(argv=None):
+    """Run the application using command-line arguments."""
+
     from transcriber.cli import build_parser
     parser = build_parser()
     if argv is None:


### PR DESCRIPTION
## Summary
- document the package and public functions
- remove unused imports

## Testing
- `ruff check .`
- `pytest -q` *(fails: ImportError cannot import name 'run')*

------
https://chatgpt.com/codex/tasks/task_b_6847b8a5147883318e41b1d505e266ab