### PR TITLE
Unify parser logic

### DIFF
--- a/transcriber/__init__.py
+++ b/transcriber/__init__.py
@@ -1,2 +1,2 @@
-__all__ = ["cli", "transcribe_slides"]
+__all__ = ["cli", "transcribe_slides", "parser"]
 __version__ = "0.1.0"

--- a/transcriber/cli.py
+++ b/transcriber/cli.py
@@ -1,123 +1,28 @@
-import argparse
-import os
-from gooey import Gooey, GooeyParser
-from transcriber.transcribe_slides import transcribe_slides
+try:
+    from gooey import Gooey
+except Exception:  # pragma: no cover - Gooey is optional
+    Gooey = None  # type: ignore
 
+from .parser import build_parser
+from .transcribe_slides import run
 
-def build_parser():
-    parser = argparse.ArgumentParser(
-        description="Transcribe slide audio using the OpenAI Speech to Text API"
+if Gooey:
+    @Gooey(
+        program_name="Slides Transcriber",
+        program_description="Extract audio from PowerPoint slides and transcribe them using OpenAI's Whisper model",
+        default_size=(800, 600),
+        tabbed_groups=True,
+        navigation="TABBED",
     )
-    parser.add_argument("pptx", help="Path to PPTX file")
-    parser.add_argument("output", help="Output directory for transcripts")
-    parser.add_argument(
-        "--model",
-        help="OpenAI STT model to use (currently only whisper-1 is available)",
-        default="whisper-1",
-        choices=["whisper-1"],
-    )
-    parser.add_argument(
-        "--language",
-        help="Language spoken in the audio (e.g., 'en' for English)",
-        default="en"
-    )
-    parser.add_argument(
-        "--task",
-        help="Transcription task",
-        choices=["transcribe", "translate"],
-        default="transcribe"
-    )
-    parser.add_argument(
-        "--prefix",
-        help="Prefix for output files",
-        default="slide"
-    )
-    parser.add_argument(
-        "--api-key",
-        help="OpenAI API key (or set OPENAI_API_KEY environment variable)",
-    )
-    parser.add_argument(
-        "--gui",
-        action="store_true",
-        help="Launch a GUI instead of the CLI",
-    )
-    return parser
-
-
-@Gooey(
-    program_name="Slides Transcriber",
-    program_description="Extract audio from PowerPoint slides and transcribe them using OpenAI's Whisper model",
-    default_size=(800, 600),
-    tabbed_groups=True,
-    navigation='TABBED'
-)
-def main():
-    parser = GooeyParser(description="Transcribe audio from PowerPoint slides")
-
-    # Input/Output group
-    io_group = parser.add_argument_group("Input/Output", gooey_options={'columns': 1})
-    io_group.add_argument(
-        "pptx_file",
-        help="Path to the PowerPoint file",
-        widget="FileChooser",
-        gooey_options={'wildcard': "PowerPoint files (*.pptx)|*.pptx"}
-    )
-    io_group.add_argument(
-        "output_dir",
-        help="Directory to save transcriptions",
-        widget="DirChooser"
-    )
-
-    # Transcription Settings group
-    trans_group = parser.add_argument_group("Transcription Settings", gooey_options={'columns': 1})
-    trans_group.add_argument(
-        "--model",
-        help="OpenAI STT model to use (currently only whisper-1 is available)",
-        default="whisper-1",
-        choices=["whisper-1"],
-        widget="Dropdown"
-    )
-    trans_group.add_argument(
-        "--language",
-        help="Language spoken in the audio (e.g., 'en' for English)",
-        default="en"
-    )
-    trans_group.add_argument(
-        "--task",
-        help="Transcription task",
-        choices=["transcribe", "translate"],
-        default="transcribe",
-        widget="Dropdown"
-    )
-    trans_group.add_argument(
-        "--prefix",
-        help="Prefix for output files",
-        default="slide"
-    )
-
-    # API Settings group
-    api_group = parser.add_argument_group("API Settings", gooey_options={'columns': 1})
-    api_group.add_argument(
-        "--api-key",
-        help="OpenAI API key (or set OPENAI_API_KEY environment variable)",
-        default=os.environ.get("OPENAI_API_KEY", ""),
-        widget="PasswordField"
-    )
-
-    args = parser.parse_args()
-
-    if not args.api_key:
-        parser.error("OpenAI API key is required. Set it via --api-key or OPENAI_API_KEY environment variable.")
-
-    transcribe_slides(
-        args.pptx_file,
-        args.output_dir,
-        model=args.model,
-        language=args.language,
-        task=args.task,
-        prefix=args.prefix,
-        api_key=args.api_key
-    )
+    def main() -> None:
+        parser = build_parser(gui=True)
+        args = parser.parse_args()
+        run(args)
+else:
+    def main() -> None:  # pragma: no cover - only used when Gooey is installed
+        parser = build_parser(gui=False)
+        args = parser.parse_args()
+        run(args)
 
 
 if __name__ == "__main__":

--- a/transcriber/parser.py
+++ b/transcriber/parser.py
@@ -1,0 +1,85 @@
+import argparse
+import os
+
+try:
+    from gooey import GooeyParser
+except Exception:  # pragma: no cover - Gooey is optional
+    GooeyParser = None  # type: ignore
+
+
+def build_parser(gui: bool = False) -> argparse.ArgumentParser:
+    """Return an argument parser for the CLI and GUI."""
+    if gui and GooeyParser:
+        parser = GooeyParser(description="Transcribe audio from PowerPoint slides")
+        io = parser.add_argument_group("Input/Output", gooey_options={"columns": 1})
+        io.add_argument(
+            "pptx",
+            help="Path to the PowerPoint file",
+            widget="FileChooser",
+            gooey_options={"wildcard": "PowerPoint files (*.pptx)|*.pptx"},
+        )
+        io.add_argument("output", help="Directory to save transcriptions", widget="DirChooser")
+
+        trans = parser.add_argument_group("Transcription Settings", gooey_options={"columns": 1})
+        trans.add_argument(
+            "--model",
+            default="whisper-1",
+            choices=["whisper-1"],
+            help="OpenAI STT model to use",
+            widget="Dropdown",
+        )
+        trans.add_argument(
+            "--language",
+            default="en",
+            help="Language spoken in the audio (e.g., 'en' for English)",
+        )
+        trans.add_argument(
+            "--task",
+            choices=["transcribe", "translate"],
+            default="transcribe",
+            help="Transcription task",
+            widget="Dropdown",
+        )
+        trans.add_argument("--prefix", default="slide", help="Prefix for output files")
+
+        api = parser.add_argument_group("API Settings", gooey_options={"columns": 1})
+        api.add_argument(
+            "--api-key",
+            default=os.environ.get("OPENAI_API_KEY", ""),
+            help="OpenAI API key (or set OPENAI_API_KEY environment variable)",
+            widget="PasswordField",
+        )
+    else:
+        parser = argparse.ArgumentParser(
+            description="Transcribe slide audio using the OpenAI Speech to Text API"
+        )
+        parser.add_argument("pptx", help="Path to PPTX file")
+        parser.add_argument("output", help="Output directory for transcripts")
+        parser.add_argument(
+            "--model",
+            default="whisper-1",
+            choices=["whisper-1"],
+            help="OpenAI STT model to use (currently only whisper-1 is available)",
+        )
+        parser.add_argument(
+            "--language",
+            default="en",
+            help="Language spoken in the audio (e.g., 'en' for English)",
+        )
+        parser.add_argument(
+            "--task",
+            choices=["transcribe", "translate"],
+            default="transcribe",
+            help="Transcription task",
+        )
+        parser.add_argument("--prefix", default="slide", help="Prefix for output files")
+        parser.add_argument(
+            "--api-key",
+            help="OpenAI API key (or set OPENAI_API_KEY environment variable)",
+        )
+        parser.add_argument(
+            "--gui",
+            action="store_true",
+            help="Launch a GUI instead of the CLI",
+        )
+    return parser


### PR DESCRIPTION
## Summary
- move parser creation to new `parser` module
- simplify CLI to use `build_parser` and `run`
- update script entrypoint to import from `parser`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6847b8966c588331b94ead3852af027c